### PR TITLE
Remove un-acceptable base types

### DIFF
--- a/pyobf2/lib/transformers/typeAliasTransformer.py
+++ b/pyobf2/lib/transformers/typeAliasTransformer.py
@@ -15,12 +15,10 @@ class TypeAliasTransformer(Transformer, NodeTransformer):
                              "int",
                              "float",
                              "filter",
-                             "bool",
                              "bytes",
                              "map",
-                             "range"
-                         ])
-                         )
+                             ]
+                         ))
         self.entries = []
 
     def visit_Name(self, node: Name) -> Any:

--- a/pyobf2/lib/transformers/typeAliasTransformer.py
+++ b/pyobf2/lib/transformers/typeAliasTransformer.py
@@ -15,10 +15,12 @@ class TypeAliasTransformer(Transformer, NodeTransformer):
                              "int",
                              "float",
                              "filter",
+                             "bool",
                              "bytes",
                              "map",
-                             ]
-                         ))
+                             "range"
+                         ])
+                         )
         self.entries = []
 
     def visit_Name(self, node: Name) -> Any:

--- a/pyobf2/lib/transformers/typeAliasTransformer.py
+++ b/pyobf2/lib/transformers/typeAliasTransformer.py
@@ -15,10 +15,8 @@ class TypeAliasTransformer(Transformer, NodeTransformer):
                              "int",
                              "float",
                              "filter",
-                             "bool",
                              "bytes",
                              "map",
-                             "range"
                          ])
                          )
         self.entries = []


### PR DESCRIPTION
Removes base types `bool` and `range` that are not permitted to be used as a base class.  Example:

 Traceback (most recent call last):
  |   File "/app/app/aws_secrets/get_aws_secrets.py", line 799, in <module>
  |     from app.app import logger
  |   File "/app/app/app.py", line 44, in <module>
  |     from app.ppjson import ppjson
  |   File "/app/app/ppjson/__init__.py", line 143, in <module>
  |     class CiYgTRr3TtTgisOJrgMeV2uWY1lWOSH8(bool):...
  | TypeError: type 'bool' is not an acceptable base type
